### PR TITLE
add ability to write a certification style json from brilcalc output

### DIFF
--- a/Scripts/makeValidNT.py
+++ b/Scripts/makeValidNT.py
@@ -6,6 +6,7 @@ parser = argparse.ArgumentParser(description='Makes a valid normtag given a CSV 
 parser.add_argument('-i', '--input', type=str, default="", help='CSV file from brilcalc.')
 parser.add_argument('-o', '--output', type=str, default="mynormtag.json", help='output file name')
 parser.add_argument('-n', '--normtag', type=str, default="pccLUM15001", help='String of normtag')
+parser.add_argument('--jsontype', type=str, default="normtag", help='normtag or cert')
 args = parser.parse_args()
 
 def CondensedList(fullList):
@@ -60,16 +61,28 @@ runs=validData.keys()
 runs.sort()
 
 outputFile=open(args.output,"w")
-outputFile.write("[\n")
+if args.jsontype.find("normtag")==0:
+    outputFile.write("[\n")
+elif args.jsontype.find("cert")==0:
+    outputFile.write("{\n")
+else:
+    print "didn't find normtag or cert in",args.jsontype
+
 for run in runs:
     validData[run].sort()
     print run, 
     print "condensed",CondensedList(validData[run])
 
     # example line:    ["hfoc16v1",{"271037":[[1,15]]}],
-    outputFile.write("[\""+args.normtag+"\",{\""+str(run)+"\":"+str(CondensedList(validData[run]))+"}]")
+    if args.jsontype.find("normtag")==0:
+        outputFile.write("[\""+args.normtag+"\",{\""+str(run)+"\":"+str(CondensedList(validData[run]))+"}]")
+    elif args.jsontype.find("cert")==0:
+        outputFile.write("\""+str(run)+"\":"+str(CondensedList(validData[run])))
     if run != runs[-1]:
         outputFile.write(",\n")
         
-outputFile.write("\n]\n")
+if args.jsontype.find("normtag")==0:
+    outputFile.write("\n]\n")
+elif args.jsontype.find("cert")==0:
+    outputFile.write("\n}\n")
 outputFile.close()


### PR DESCRIPTION
@plujan this makes a certification style json file from brilcalc csv file input.  Just use the "--jsontype cert" argument.  I needed this at somepoint for a filter.