### PR TITLE
compute minimal correlation scheme

### DIFF
--- a/Scripts/combineYears.py
+++ b/Scripts/combineYears.py
@@ -184,8 +184,6 @@ for i in range(len(years)):
 
 
 print "\n\nSimplified scheme\n"
-print years,len(years)
-print uncertainties.keys()
 
 mergedUncertSquared={}
 for uncert in uncertainties:

--- a/Scripts/luminosity_all_years.txt
+++ b/Scripts/luminosity_all_years.txt
@@ -13,7 +13,8 @@ X-Y factorization,             C,   0.5, 0.5, 0.8, 2.0
 Length scale,                  C,   0.2, 0.3, 0.3, 0.2
 Orbit drift Syst,              C,   0.8, 0.5, 0.0, 0.0
 Orbit drift Rand,              U,   0.2, 0.1, 0.2, 0.1
-Beam-beam effects,             C,   0.5, 0.5, 0.6, 0.2
+Beam-beam effects (15-16),     C,   0.5, 0.5, 0.0, 0.0
+Beam-beam effects (17-18),     C,   0.0, 0.0, 0.6, 0.2
 Beam current calibration,      C,   0.2, 0.2, 0.3, 0.2
 Ghosts and satellites,         C,   0.1, 0.1, 0.1, 0.1
 Scan to scan variation,        U,   0.5, 0.2, 0.9, 0.3


### PR DESCRIPTION
For 2016, 2017, 2018 it is very simple now because 2016 systematics are now correlated with 2017 and 2018 (or completely uncorrelated among the three).

`
201620172018 0.8 1.1 2.0

2016 0.9

2017 2.0

2018 1.5
`

@gkrintir I'm not sure how this should be formatted.  Please let me know how you think it should look and I'll try to match that.  